### PR TITLE
prompt for git identity on first setup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
     envHost = builtins.getEnv "HOSTNAME";
     user = if envUser == "" || envUser == "root" then builtins.getEnv "SUDO_USER" else envUser;
     host = if envHost == "" then "macbook" else envHost;
+    gitUserName = let v = builtins.getEnv "GIT_USER_NAME"; in if v == "" then "sidux" else v;
+    gitUserEmail = let v = builtins.getEnv "GIT_USER_EMAIL"; in if v == "" then "ahmed.lebbada@gmail.com" else v;
   in
   {
     darwinConfigurations."${host}" = darwin.lib.darwinSystem {
@@ -58,8 +60,8 @@
                 ".envrc.local"        # Local direnv overrides
               ];
               settings = {
-                user.name = "sidux";
-                user.email = "ahmed.lebbada@gmail.com";
+                user.name = gitUserName;
+                user.email = gitUserEmail;
                 core.editor = "vim";
                 color.ui = true;
                 init.defaultBranch = "main";

--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,28 @@ fi
 # Get the directory where this script lives
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Warn if repo is not at ~/dotfiles (aliases and iTerm2 config expect this path)
+EXPECTED_DIR="$HOME/dotfiles"
+if [ "$SCRIPT_DIR" != "$EXPECTED_DIR" ]; then
+    echo "Warning: this repo is at $SCRIPT_DIR but some config expects ~/dotfiles."
+    echo "  - The 'nix-build' fish alias will point to $EXPECTED_DIR/setup.sh (broken)"
+    echo "  - iTerm2 will look for preferences at $EXPECTED_DIR/iterm (broken)"
+    read -rp "Continue anyway? [y/N]: " confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+fi
+
 # Export hostname for flake (macOS doesn't set HOSTNAME by default)
 export HOSTNAME=$(hostname -s)
+
+# Prompt for git identity if not already set via environment
+if [ -z "$GIT_USER_NAME" ]; then
+    read -rp "Git user name [sidux]: " input_name
+    export GIT_USER_NAME="${input_name:-}"
+fi
+if [ -z "$GIT_USER_EMAIL" ]; then
+    read -rp "Git user email [ahmed.lebbada@gmail.com]: " input_email
+    export GIT_USER_EMAIL="${input_email:-}"
+fi
 
 echo "Building nix-darwin for user: $USER, host: $HOSTNAME"
 


### PR DESCRIPTION
## Summary

- `setup.sh` now prompts for git name and email at install time, with the original values (`sidux` / `ahmed.lebbada@gmail.com`) as defaults — press Enter to keep them, or type your own
- `flake.nix` reads `GIT_USER_NAME` and `GIT_USER_EMAIL` env vars (passed by the script) instead of hardcoding the values
- `setup.sh` warns and asks for confirmation if the repo is not cloned at `~/dotfiles`, since the fish aliases (`nix-build`) and iTerm2 preferences path depend on that location

## Test plan

- [ ] Run `setup.sh` from `~/dotfiles` → prompted for name/email, pressing Enter uses defaults
- [ ] Run `setup.sh` with custom values → git config reflects them after activation
- [ ] Run `setup.sh` from a different path → warning is displayed and script exits on `N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)